### PR TITLE
State f32-py38

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,11 +5,15 @@ s2i-thoth
 
 .. |s2i-thoth-f31-py37 on Quay| image:: https://quay.io/repository/thoth-station/s2i-thoth-f31-py37/status
 
+.. |s2i-thoth-f32-py38 on Quay| image:: https://quay.io/repository/thoth-station/s2i-thoth-f32-py38/status
+
 Experimental Thoth container images:
 
 * `quay.io/thoth-station/s2i-thoth-ubi8-py36 <https://quay.io/repository/thoth-station/s2i-thoth-ubi8-py36>`_ |s2i-thoth-ubi8-py36 on Quay|
 
 * `quay.io/thoth-station/s2i-thoth-f31-py37 <https://quay.io/repository/thoth-station/s2i-thoth-f31-py37>`_ |s2i-thoth-f31-py37 on Quay| 
+
+* `quay.io/thoth-station/s2i-thoth-f32-py38 <https://quay.io/repository/thoth-station/s2i-thoth-f32-py38>`_ |s2i-thoth-f32-py38 on Quay| 
 
 Artifacts needed to build `s2i-thoth-*` container images.
 


### PR DESCRIPTION
By stating s2i-thoth-f32-py38 in the README file, we will make this base image visible to thoth-s2i tool.