### PR TITLE
Fix building Fedora based s2i container images

### DIFF
--- a/f31-py37/Dockerfile
+++ b/f31-py37/Dockerfile
@@ -23,9 +23,10 @@ LABEL summary="$SUMMARY" \
 
 USER 0
 COPY ./s2i_assemble.patch /tmp/s2i_assemble.patch
-RUN TMPFILE=$(mktemp) &&
+RUN TMPFILE=$(mktemp) && \
     TMPFILE_ASSEMBLE=$(mktemp) && \
     pushd "${STI_SCRIPTS_PATH}" && patch -p 1 </tmp/s2i_assemble.patch && popd && \
+    /usr/bin/pip3 install -U "pip==20.1.1" && \
     /usr/bin/pip3 install micropipenv[toml]==0.2.0 thamos==0.10.0 && \
     curl "https://raw.githubusercontent.com/thoth-station/s2i-thoth/master/assemble" -o "${TMPFILE_ASSEMBLE}" && \
     cp "${STI_SCRIPTS_PATH}/assemble" "${TMPFILE}" && \

--- a/f31-py37/s2i_assemble.patch
+++ b/f31-py37/s2i_assemble.patch
@@ -1,34 +1,54 @@
-diff --git a/assemble b/assemble
-index c6515b5..3da074c 100755
---- a/assemble
-+++ b/assemble
-@@ -18,20 +18,6 @@ function virtualenv_bin() {
-   fi
+--- a/asseble	2020-06-05 09:22:15.714337470 +0200
++++ b/assemble	2020-06-05 09:21:48.059105881 +0200
+@@ -14,30 +14,8 @@
+     python3.7 -m venv $1
  }
  
--# Install pipenv to the separate virtualenv to isolate it
+-# Install pipenv or micropipenv to the separate virtualenv to isolate it
 -# from system Python packages and packages in the main
 -# virtualenv. Executable is simlinked into ~/.local/bin
 -# to be accessible. This approach is inspired by pipsi
 -# (pip script installer).
--function install_pipenv() {
--  echo "---> Installing pipenv packaging tool ..."
--  VENV_DIR=$HOME/.local/venvs/pipenv
+-function install_tool() {
+-  echo "---> Installing $1 packaging tool ..."
+-  VENV_DIR=$HOME/.local/venvs/$1
 -  virtualenv_bin "$VENV_DIR"
--  $VENV_DIR/bin/pip --isolated install -U pipenv
+-  $VENV_DIR/bin/pip --isolated install -U $1$2  # Combines package name with [extras] if [extras] is defined as $2
 -  mkdir -p $HOME/.local/bin
--  ln -s $VENV_DIR/bin/pipenv $HOME/.local/bin/pipenv
+-  ln -s $VENV_DIR/bin/$1 $HOME/.local/bin/$1
 -}
 -
  set -e
  
+-# First of all, check that we don't have disallowed combination of ENVs
+-if [[ ! -z "$ENABLE_PIPENV" && ! -z "$ENABLE_MICROPIPENV" ]]; then
+-  echo "ERROR: Pipenv and micropipenv cannot be enabled at the same time!"
+-  # podman/buildah does not relay this exit code but it will be fixed hopefuly
+-  # https://github.com/containers/buildah/issues/2305
+-  exit 3
+-fi
+-
  shopt -s dotglob
-@@ -46,19 +32,8 @@ if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
+ echo "---> Installing application source ..."
+ mv /tmp/src/* "$HOME"
+@@ -45,36 +23,14 @@
+ # set permissions for any installed artifacts
+ fix-permissions /opt/app-root -P
+ 
+-# We have to first upgrade pip to at least 19.3 because:
+-# * pip < 9 does not support different packages' versions for Python 2/3
+-# * pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 wheels
+-#   support platforms like ppc64le, aarch64 or armv7
+-echo "---> Upgrading pip to version 19.3.1 ..."
+-pip install -U "pip==19.3.1"
+-
+ if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
+   echo "---> Upgrading pip to latest version ..."
    pip install -U pip setuptools wheel
  fi
  
 -if [[ ! -z "$ENABLE_PIPENV" ]]; then
--  install_pipenv
+-  install_tool "pipenv" "==2018.11.26"
 -  echo "---> Installing dependencies via pipenv ..."
 -  if [[ -f Pipfile ]]; then
 -    pipenv install --deploy
@@ -36,11 +56,17 @@ index c6515b5..3da074c 100755
 -    pipenv install -r requirements.txt
 -  fi
 -  # pipenv check
+-elif [[ ! -z "$ENABLE_MICROPIPENV" ]]; then
+-  install_tool "micropipenv" "[toml]"
+-  echo "---> Installing dependencies via micropipenv ..."
+-  # micropipenv detects Pipfile.lock and requirements.txt in this order
+-  micropipenv install --deploy
 -elif [[ -f requirements.txt ]]; then
 -  echo "---> Installing dependencies ..."
 -  pip install -r requirements.txt
 -fi
 +echo "---> Installing dependencies via micropipenv ..."
++# micropipenv detects Pipfile.lock and requirements.txt in this order
 +micropipenv install --deploy
  
  if [[ -f setup.py && -z "$DISABLE_SETUP_PY_PROCESSING" ]]; then

--- a/f32-py38/Dockerfile
+++ b/f32-py38/Dockerfile
@@ -26,6 +26,7 @@ COPY ./s2i_assemble.patch /tmp/s2i_assemble.patch
 RUN TMPFILE=$(mktemp) && \
     TMPFILE_ASSEMBLE=$(mktemp) && \
     pushd "${STI_SCRIPTS_PATH}" && patch -p 1 </tmp/s2i_assemble.patch && popd && \
+    /usr/bin/pip3 install -U "pip==20.1.1" && \
     /usr/bin/pip3 install micropipenv[toml]==0.2.0 thamos==0.10.0 && \
     curl "https://raw.githubusercontent.com/thoth-station/s2i-thoth/master/assemble" -o "${TMPFILE_ASSEMBLE}" && \
     cp "${STI_SCRIPTS_PATH}/assemble" "${TMPFILE}" && \

--- a/f32-py38/s2i_assemble.patch
+++ b/f32-py38/s2i_assemble.patch
@@ -1,34 +1,54 @@
-diff --git a/assemble b/assemble
-index c6515b5..3da074c 100755
---- a/assemble
-+++ b/assemble
-@@ -18,20 +18,6 @@ function virtualenv_bin() {
-   fi
+--- a/asseble	2020-06-05 09:22:15.714337470 +0200
++++ b/assemble	2020-06-05 09:21:48.059105881 +0200
+@@ -14,30 +14,8 @@
+     python3.8 -m venv $1
  }
  
--# Install pipenv to the separate virtualenv to isolate it
+-# Install pipenv or micropipenv to the separate virtualenv to isolate it
 -# from system Python packages and packages in the main
 -# virtualenv. Executable is simlinked into ~/.local/bin
 -# to be accessible. This approach is inspired by pipsi
 -# (pip script installer).
--function install_pipenv() {
--  echo "---> Installing pipenv packaging tool ..."
--  VENV_DIR=$HOME/.local/venvs/pipenv
+-function install_tool() {
+-  echo "---> Installing $1 packaging tool ..."
+-  VENV_DIR=$HOME/.local/venvs/$1
 -  virtualenv_bin "$VENV_DIR"
--  $VENV_DIR/bin/pip --isolated install -U pipenv
+-  $VENV_DIR/bin/pip --isolated install -U $1$2  # Combines package name with [extras] if [extras] is defined as $2
 -  mkdir -p $HOME/.local/bin
--  ln -s $VENV_DIR/bin/pipenv $HOME/.local/bin/pipenv
+-  ln -s $VENV_DIR/bin/$1 $HOME/.local/bin/$1
 -}
 -
  set -e
  
+-# First of all, check that we don't have disallowed combination of ENVs
+-if [[ ! -z "$ENABLE_PIPENV" && ! -z "$ENABLE_MICROPIPENV" ]]; then
+-  echo "ERROR: Pipenv and micropipenv cannot be enabled at the same time!"
+-  # podman/buildah does not relay this exit code but it will be fixed hopefuly
+-  # https://github.com/containers/buildah/issues/2305
+-  exit 3
+-fi
+-
  shopt -s dotglob
-@@ -46,19 +32,8 @@ if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
+ echo "---> Installing application source ..."
+ mv /tmp/src/* "$HOME"
+@@ -45,36 +23,14 @@
+ # set permissions for any installed artifacts
+ fix-permissions /opt/app-root -P
+ 
+-# We have to first upgrade pip to at least 19.3 because:
+-# * pip < 9 does not support different packages' versions for Python 2/3
+-# * pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 wheels
+-#   support platforms like ppc64le, aarch64 or armv7
+-echo "---> Upgrading pip to version 19.3.1 ..."
+-pip install -U "pip==19.3.1"
+-
+ if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
+   echo "---> Upgrading pip to latest version ..."
    pip install -U pip setuptools wheel
  fi
  
 -if [[ ! -z "$ENABLE_PIPENV" ]]; then
--  install_pipenv
+-  install_tool "pipenv" "==2018.11.26"
 -  echo "---> Installing dependencies via pipenv ..."
 -  if [[ -f Pipfile ]]; then
 -    pipenv install --deploy
@@ -36,11 +56,17 @@ index c6515b5..3da074c 100755
 -    pipenv install -r requirements.txt
 -  fi
 -  # pipenv check
+-elif [[ ! -z "$ENABLE_MICROPIPENV" ]]; then
+-  install_tool "micropipenv" "[toml]"
+-  echo "---> Installing dependencies via micropipenv ..."
+-  # micropipenv detects Pipfile.lock and requirements.txt in this order
+-  micropipenv install --deploy
 -elif [[ -f requirements.txt ]]; then
 -  echo "---> Installing dependencies ..."
 -  pip install -r requirements.txt
 -fi
 +echo "---> Installing dependencies via micropipenv ..."
++# micropipenv detects Pipfile.lock and requirements.txt in this order
 +micropipenv install --deploy
  
  if [[ -f setup.py && -z "$DISABLE_SETUP_PY_PROCESSING" ]]; then


### PR DESCRIPTION
As the assemble script changed with the micropipenv introduction, we need to adjust our patches. Otherwise builds fail.