### PR TITLE
Fix Fedora based s2i-thoth builds

### DIFF
--- a/f31-py37/s2i_assemble.patch
+++ b/f31-py37/s2i_assemble.patch
@@ -1,73 +1,11 @@
---- a/asseble	2020-06-05 09:22:15.714337470 +0200
-+++ b/assemble	2020-06-05 09:21:48.059105881 +0200
-@@ -14,30 +14,8 @@
-     python3.7 -m venv $1
- }
+--- a/assemble	2020-08-26 08:36:24.689696930 +0200
++++ b/assemble	2020-08-26 08:38:32.765236073 +0200
+@@ -1,4 +1,7 @@
+ #!/bin/bash
++# Thoth's addition always uses micropipenv.
++unset ENABLE_PIPENV
++export ENABLE_MICROPIPENV=1
  
--# Install pipenv or micropipenv to the separate virtualenv to isolate it
--# from system Python packages and packages in the main
--# virtualenv. Executable is simlinked into ~/.local/bin
--# to be accessible. This approach is inspired by pipsi
--# (pip script installer).
--function install_tool() {
--  echo "---> Installing $1 packaging tool ..."
--  VENV_DIR=$HOME/.local/venvs/$1
--  virtualenv_bin "$VENV_DIR"
--  $VENV_DIR/bin/pip --isolated install -U $1$2  # Combines package name with [extras] if [extras] is defined as $2
--  mkdir -p $HOME/.local/bin
--  ln -s $VENV_DIR/bin/$1 $HOME/.local/bin/$1
--}
--
- set -e
- 
--# First of all, check that we don't have disallowed combination of ENVs
--if [[ ! -z "$ENABLE_PIPENV" && ! -z "$ENABLE_MICROPIPENV" ]]; then
--  echo "ERROR: Pipenv and micropipenv cannot be enabled at the same time!"
--  # podman/buildah does not relay this exit code but it will be fixed hopefuly
--  # https://github.com/containers/buildah/issues/2305
--  exit 3
--fi
--
- shopt -s dotglob
- echo "---> Installing application source ..."
- mv /tmp/src/* "$HOME"
-@@ -45,36 +23,14 @@
- # set permissions for any installed artifacts
- fix-permissions /opt/app-root -P
- 
--# We have to first upgrade pip to at least 19.3 because:
--# * pip < 9 does not support different packages' versions for Python 2/3
--# * pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 wheels
--#   support platforms like ppc64le, aarch64 or armv7
--echo "---> Upgrading pip to version 19.3.1 ..."
--pip install -U "pip==19.3.1"
--
- if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
-   echo "---> Upgrading pip to latest version ..."
-   pip install -U pip setuptools wheel
- fi
- 
--if [[ ! -z "$ENABLE_PIPENV" ]]; then
--  install_tool "pipenv" "==2018.11.26"
--  echo "---> Installing dependencies via pipenv ..."
--  if [[ -f Pipfile ]]; then
--    pipenv install --deploy
--  elif [[ -f requirements.txt ]]; then
--    pipenv install -r requirements.txt
--  fi
--  # pipenv check
--elif [[ ! -z "$ENABLE_MICROPIPENV" ]]; then
--  install_tool "micropipenv" "[toml]"
--  echo "---> Installing dependencies via micropipenv ..."
--  # micropipenv detects Pipfile.lock and requirements.txt in this order
--  micropipenv install --deploy
--elif [[ -f requirements.txt ]]; then
--  echo "---> Installing dependencies ..."
--  pip install -r requirements.txt
--fi
-+echo "---> Installing dependencies via micropipenv ..."
-+# micropipenv detects Pipfile.lock and requirements.txt in this order
-+micropipenv install --deploy
- 
- if [[ -f setup.py && -z "$DISABLE_SETUP_PY_PROCESSING" ]]; then
-   echo "---> Installing application ..."
+ function is_django_installed() {
+   python -c "import django" &>/dev/null
+

--- a/f32-py38/s2i_assemble.patch
+++ b/f32-py38/s2i_assemble.patch
@@ -1,73 +1,11 @@
---- a/asseble	2020-06-05 09:22:15.714337470 +0200
-+++ b/assemble	2020-06-05 09:21:48.059105881 +0200
-@@ -14,30 +14,8 @@
-     python3.8 -m venv $1
- }
+--- a/assemble	2020-08-26 08:36:24.689696930 +0200
++++ b/assemble	2020-08-26 08:38:32.765236073 +0200
+@@ -1,4 +1,7 @@
+ #!/bin/bash
++# Thoth's addition always uses micropipenv.
++unset ENABLE_PIPENV
++export ENABLE_MICROPIPENV=1
  
--# Install pipenv or micropipenv to the separate virtualenv to isolate it
--# from system Python packages and packages in the main
--# virtualenv. Executable is simlinked into ~/.local/bin
--# to be accessible. This approach is inspired by pipsi
--# (pip script installer).
--function install_tool() {
--  echo "---> Installing $1 packaging tool ..."
--  VENV_DIR=$HOME/.local/venvs/$1
--  virtualenv_bin "$VENV_DIR"
--  $VENV_DIR/bin/pip --isolated install -U $1$2  # Combines package name with [extras] if [extras] is defined as $2
--  mkdir -p $HOME/.local/bin
--  ln -s $VENV_DIR/bin/$1 $HOME/.local/bin/$1
--}
--
- set -e
- 
--# First of all, check that we don't have disallowed combination of ENVs
--if [[ ! -z "$ENABLE_PIPENV" && ! -z "$ENABLE_MICROPIPENV" ]]; then
--  echo "ERROR: Pipenv and micropipenv cannot be enabled at the same time!"
--  # podman/buildah does not relay this exit code but it will be fixed hopefuly
--  # https://github.com/containers/buildah/issues/2305
--  exit 3
--fi
--
- shopt -s dotglob
- echo "---> Installing application source ..."
- mv /tmp/src/* "$HOME"
-@@ -45,36 +23,14 @@
- # set permissions for any installed artifacts
- fix-permissions /opt/app-root -P
- 
--# We have to first upgrade pip to at least 19.3 because:
--# * pip < 9 does not support different packages' versions for Python 2/3
--# * pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 wheels
--#   support platforms like ppc64le, aarch64 or armv7
--echo "---> Upgrading pip to version 19.3.1 ..."
--pip install -U "pip==19.3.1"
--
- if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
-   echo "---> Upgrading pip to latest version ..."
-   pip install -U pip setuptools wheel
- fi
- 
--if [[ ! -z "$ENABLE_PIPENV" ]]; then
--  install_tool "pipenv" "==2018.11.26"
--  echo "---> Installing dependencies via pipenv ..."
--  if [[ -f Pipfile ]]; then
--    pipenv install --deploy
--  elif [[ -f requirements.txt ]]; then
--    pipenv install -r requirements.txt
--  fi
--  # pipenv check
--elif [[ ! -z "$ENABLE_MICROPIPENV" ]]; then
--  install_tool "micropipenv" "[toml]"
--  echo "---> Installing dependencies via micropipenv ..."
--  # micropipenv detects Pipfile.lock and requirements.txt in this order
--  micropipenv install --deploy
--elif [[ -f requirements.txt ]]; then
--  echo "---> Installing dependencies ..."
--  pip install -r requirements.txt
--fi
-+echo "---> Installing dependencies via micropipenv ..."
-+# micropipenv detects Pipfile.lock and requirements.txt in this order
-+micropipenv install --deploy
- 
- if [[ -f setup.py && -z "$DISABLE_SETUP_PY_PROCESSING" ]]; then
-   echo "---> Installing application ..."
+ function is_django_installed() {
+   python -c "import django" &>/dev/null
+


### PR DESCRIPTION
The assemble script has changed when micropipenv was introduced and our patch
no longer applies.