### PR TITLE
Revert "Fix usage of Python libs when printing Thoth's configuration"

### DIFF
--- a/assemble
+++ b/assemble
@@ -58,7 +58,7 @@ function restore_lock() {
   echo ">>> Performing hardware and software discovery..."
   thamos config --no-interactive || exit 1
   echo ">>> Thoth's configuration file after hardware and software discovery:"
-  cat .thoth.yaml | python3 -c "import yaml; import json; import sys; json.dump(yaml.safe_load(sys.stdin), sys.stdout, indent=2);"
+  cat .thoth.yaml | /usr/bin/python3 -c "import yaml; import json; import sys; json.dump(yaml.safe_load(sys.stdin), sys.stdout, indent=2);"
   echo -e "\n>>> Asking Thoth for advise..."
   if [[ ${THOTH_DRY_RUN} -eq 0 ]]; then
     thamos advise || {


### PR DESCRIPTION
Reverts thoth-station/s2i-thoth#119

The Python invocation here is actually correct. We do not install our tooling into system packages. That is bad as they can collide with packages present in the virtual environment.