### PR TITLE
Explicitly provide micropipenv env vars to s2i

### DIFF
--- a/f31-py37/Dockerfile
+++ b/f31-py37/Dockerfile
@@ -6,7 +6,9 @@ ENV SUMMARY="Thoth's Source-to-Image for Python ${PYTHON_VERSION} applications" 
     THOTH_S2I_NAME=quay.io/thoth-station/s2i-thoth-f31-py37 \
     THOTH_S2I_VERSION=0.26.0 \
     THAMOS_NO_PROGRESSBAR=1 \
-    THAMOS_NO_EMOJI=1
+    THAMOS_NO_EMOJI=1 \
+    MICROPIPENV_NO_LOCKFILE_PRINT=0 \
+    MICROPIPENV_NO_LOCKFILE_WRITE=0
 
 LABEL summary="$SUMMARY" \
     description="$DESCRIPTION" \

--- a/f32-py38/Dockerfile
+++ b/f32-py38/Dockerfile
@@ -6,7 +6,9 @@ ENV SUMMARY="Thoth's Source-to-Image for Python ${PYTHON_VERSION} applications" 
     THOTH_S2I_NAME=quay.io/thoth-station/s2i-thoth-f32-py38 \
     THOTH_S2I_VERSION=0.26.0 \
     THAMOS_NO_PROGRESSBAR=1 \
-    THAMOS_NO_EMOJI=1
+    THAMOS_NO_EMOJI=1 \
+    MICROPIPENV_NO_LOCKFILE_PRINT=0 \
+    MICROPIPENV_NO_LOCKFILE_WRITE=0
 
 LABEL summary="$SUMMARY" \
     description="$DESCRIPTION" \

--- a/ubi8-py36/Dockerfile
+++ b/ubi8-py36/Dockerfile
@@ -6,7 +6,9 @@ ENV SUMMARY="Thoth's Source-to-Image for Python ${PYTHON_VERSION} applications" 
     THOTH_S2I_NAME=quay.io/thoth-station/s2i-thoth-ubi8-py36 \
     THOTH_S2I_VERSION=0.26.0 \
     THAMOS_NO_PROGRESSBAR=1 \
-    THAMOS_NO_EMOJI=1
+    THAMOS_NO_EMOJI=1 \
+    MICROPIPENV_NO_LOCKFILE_PRINT=0 \
+    MICROPIPENV_NO_LOCKFILE_WRITE=0
 
 LABEL summary="$SUMMARY" \
     description="$DESCRIPTION" \

--- a/ubi8-py38/Dockerfile
+++ b/ubi8-py38/Dockerfile
@@ -6,7 +6,9 @@ ENV SUMMARY="Thoth's Source-to-Image for Python ${PYTHON_VERSION} applications" 
     THOTH_S2I_NAME=quay.io/thoth-station/s2i-thoth-ubi8-py38 \
     THOTH_S2I_VERSION=0.26.0 \
     THAMOS_NO_PROGRESSBAR=1 \
-    THAMOS_NO_EMOJI=1
+    THAMOS_NO_EMOJI=1 \
+    MICROPIPENV_NO_LOCKFILE_PRINT=0 \
+    MICROPIPENV_NO_LOCKFILE_WRITE=0
 
 LABEL summary="$SUMMARY" \
     description="$DESCRIPTION" \


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/thamos/pull/800

## This introduces a breaking change

- [x] No

## This Pull Request implements

Let's turn on writing and printing the lock file so that `thamos install` will pick these.