### PR TITLE
Update base image to python-38:1-60 and patch yum update

### DIFF
--- a/ubi8-py38/Dockerfile
+++ b/ubi8-py38/Dockerfile
@@ -1,5 +1,5 @@
 # Thoth's extension to OpenShift's S2I build
-FROM registry.access.redhat.com/ubi8/python-38:1-47
+FROM registry.access.redhat.com/ubi8/python-38:1-60
 
 ENV SUMMARY="Thoth's Source-to-Image for Python ${PYTHON_VERSION} applications" \
     DESCRIPTION="Thoth's Source-to-Image for Python ${PYTHON_VERSION} applications. This toolchain is based on Red Hat UBI8. It includes pipenv." \
@@ -42,6 +42,6 @@ RUN TMPFILE=$(mktemp) && \
     sed -i '/  echo "---> Running application from .*/d' "${STI_SCRIPTS_PATH}/run" && \
     chown -R 1001:0 ${APP_ROOT} && \
     fix-permissions ${APP_ROOT} -P && \
-    yum update --assumeyes --setopt=tsflags=nodocs
+    yum update --assumeyes --nobest --setopt=tsflags=nodocs
 
 USER 1001


### PR DESCRIPTION
The update of perl is broken at the moment. Changing the base
image to latest (1-60) and adding --nobest on update in the
Dockerfile allows yum to skip the perl update and the build completes.

## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

… Explain your changes.

## Description

Build of the ubi8-py38/Dockerfile gives the following output from the last command in the Dockerfile (yum update)

```
Problem 1: package perl-threads-1:2.21-2.el8.x86_64 requires libperl.so.5.26()(64bit), but none of the providers can be installed
  - cannot install both perl-libs-4:5.30.1-451.module+el8.3.0+6961+31ca2e7a.x86_64 and perl-libs-4:5.26.3-419.el8.x86_64
  - cannot install the best update candidate for package perl-threads-1:2.21-2.el8.x86_64
  - cannot install the best update candidate for package perl-libs-4:5.26.3-419.el8.x86_64
 Problem 2: package perl-threads-shared-1.58-2.el8.x86_64 requires libperl.so.5.26()(64bit), but none of the providers can be installed
  - cannot install both perl-libs-4:5.30.1-451.module+el8.3.0+6961+31ca2e7a.x86_64 and perl-libs-4:5.26.3-419.el8.x86_64
  - package perl-Errno-1.30-451.module+el8.3.0+6961+31ca2e7a.x86_64 requires perl(:MODULE_COMPAT_5.30.1), but none of the providers can be installed
  - cannot install the best update candidate for package perl-threads-shared-1.58-2.el8.x86_64
  - cannot install the best update candidate for package perl-Errno-1.28-419.el8.x86_64
  - package perl-libs-4:5.30.1-452.module+el8.4.0+8990+01326e37.x86_64 is filtered out by modular filtering
 Problem 3: package perl-Unicode-Normalize-1.25-396.el8.x86_64 requires libperl.so.5.26()(64bit), but none of the providers can be installed
  - cannot install both perl-libs-4:5.30.1-451.module+el8.3.0+6961+31ca2e7a.x86_64 and perl-libs-4:5.26.3-419.el8.x86_64
  - package perl-IO-1.40-451.module+el8.3.0+6961+31ca2e7a.x86_64 requires perl(:MODULE_COMPAT_5.30.1), but none of the providers can be installed
  - package perl-IO-1.40-451.module+el8.3.0+6961+31ca2e7a.x86_64 requires libperl.so.5.30()(64bit), but none of the providers can be installed
  - cannot install the best update candidate for package perl-Unicode-Normalize-1.25-396.el8.x86_64
  - cannot install the best update candidate for package perl-IO-1.38-419.el8.x86_64
  - package perl-libs-4:5.30.1-452.module+el8.4.0+8990+01326e37.x86_64 is filtered out by modular filtering
 Problem 4: package perl-TermReadKey-2.37-7.el8.x86_64 requires libperl.so.5.26()(64bit), but none of the providers can be installed
  - cannot install both perl-libs-4:5.30.1-451.module+el8.3.0+6961+31ca2e7a.x86_64 and perl-libs-4:5.26.3-419.el8.x86_64
  - package perl-interpreter-4:5.30.1-451.module+el8.3.0+6961+31ca2e7a.x86_64 requires perl(:MODULE_COMPAT_5.30.1), but none of the providers can be installed
  - package perl-interpreter-4:5.30.1-451.module+el8.3.0+6961+31ca2e7a.x86_64 requires libperl.so.5.30()(64bit), but none of the providers can be installed
  - cannot install the best update candidate for package perl-interpreter-4:5.26.3-419.el8.x86_64
  - cannot install the best update candidate for package perl-TermReadKey-2.37-7.el8.x86_64
  - package perl-libs-4:5.30.1-452.module+el8.4.0+8990+01326e37.x86_64 is filtered out by modular filtering
 Problem 5: package perl-Storable-1:3.11-3.el8.x86_64 requires libperl.so.5.26()(64bit), but none of the providers can be installed
  - cannot install both perl-libs-4:5.30.1-451.module+el8.3.0+6961+31ca2e7a.x86_64 and perl-libs-4:5.26.3-419.el8.x86_64
  - package perl-macros-4:5.30.1-451.module+el8.3.0+6961+31ca2e7a.x86_64 requires perl(:MODULE_COMPAT_5.30.1), but none of the providers can be installed
  - cannot install the best update candidate for package perl-macros-4:5.26.3-419.el8.x86_64
  - cannot install the best update candidate for package perl-Storable-1:3.11-3.el8.x86_64
  - package perl-libs-4:5.30.1-452.module+el8.4.0+8990+01326e37.x86_64 is filtered out by modular filtering
```

This looks like it stems from an update to perl packages. The included change allows the build to complete, skipping only some perl updates

```
Skipping packages with conflicts:
(add '--best --allowerasing' to command line to force their upgrade):
 perl-libs          x86_64  4:5.30.1-451.module+el8.3.0+6961+31ca2e7a ubi-8-appstream  1.8 M
Skipping packages with broken dependencies:
 perl-Errno         x86_64  1.30-451.module+el8.3.0+6961+31ca2e7a     ubi-8-appstream   85 k
 perl-IO            x86_64  1.40-451.module+el8.3.0+6961+31ca2e7a     ubi-8-appstream  152 k
 perl-interpreter   x86_64  4:5.30.1-451.module+el8.3.0+6961+31ca2e7a ubi-8-appstream  6.5 M
 perl-macros        x86_64  4:5.30.1-451.module+el8.3.0+6961+31ca2e7a ubi-8-appstream   81 k
```


