### PR TITLE
Avoid installing non user packages in s2i virtualenv

### DIFF
--- a/f34-py39/Dockerfile
+++ b/f34-py39/Dockerfile
@@ -32,7 +32,7 @@ RUN TMPFILE=$(mktemp) && \
     pip3 install -U "pip==20.3.3" && \
     /usr/bin/pip3 install -U "pip==20.3.3" && \
     curl "https://raw.githubusercontent.com/thoth-station/s2i-thoth/master/f34-py39/requirements.txt" -o requirements.txt && \
-    MICROPIPENV_NO_LOCKFILE_WRITE=1 MICROPIPENV_PIP_BIN=/usr/bin/pip3 curl https://raw.githubusercontent.com/thoth-station/micropipenv/master/micropipenv.py | /usr/bin/python3 - install -- && \
+    curl https://raw.githubusercontent.com/thoth-station/micropipenv/master/micropipenv.py | MICROPIPENV_NO_LOCKFILE_WRITE=1 MICROPIPENV_PIP_BIN=/usr/bin/pip3 /usr/bin/python3 - install -- && \
     curl "https://raw.githubusercontent.com/thoth-station/s2i-thoth/master/assemble" -o "${TMPFILE_ASSEMBLE}" && \
     cp "${STI_SCRIPTS_PATH}/assemble" "${TMPFILE}" && \
     head -n1 "${TMPFILE}" >"${STI_SCRIPTS_PATH}/assemble" && \

--- a/ubi8-py36/Dockerfile
+++ b/ubi8-py36/Dockerfile
@@ -32,7 +32,7 @@ RUN TMPFILE=$(mktemp) && \
     pip3 install -U "pip==20.3.3" && \
     /usr/bin/pip3 install -U "pip==20.3.3" && \
     curl "https://raw.githubusercontent.com/thoth-station/s2i-thoth/master/ubi8-py36/requirements.txt" -o requirements.txt && \
-    MICROPIPENV_NO_LOCKFILE_WRITE=1 MICROPIPENV_PIP_BIN=/usr/bin/pip3 curl https://raw.githubusercontent.com/thoth-station/micropipenv/master/micropipenv.py | /usr/bin/python3 - install -- && \
+    curl https://raw.githubusercontent.com/thoth-station/micropipenv/master/micropipenv.py | MICROPIPENV_NO_LOCKFILE_WRITE=1 MICROPIPENV_PIP_BIN=/usr/bin/pip3 /usr/bin/python3 - install -- && \
     curl "https://raw.githubusercontent.com/thoth-station/s2i-thoth/master/assemble" -o "${TMPFILE_ASSEMBLE}" && \
     cp "${STI_SCRIPTS_PATH}/assemble" "${TMPFILE}" && \
     head -n1 "${TMPFILE}" >"${STI_SCRIPTS_PATH}/assemble" && \

--- a/ubi8-py38/Dockerfile
+++ b/ubi8-py38/Dockerfile
@@ -32,7 +32,7 @@ RUN TMPFILE=$(mktemp) && \
     pip3 install -U "pip==20.3.3" && \
     /usr/bin/pip3 install -U "pip==20.3.3" && \
     curl "https://raw.githubusercontent.com/thoth-station/s2i-thoth/master/ubi8-py38/requirements.txt" -o requirements.txt && \
-    MICROPIPENV_NO_LOCKFILE_WRITE=1 MICROPIPENV_PIP_BIN=/usr/bin/pip3 curl https://raw.githubusercontent.com/thoth-station/micropipenv/master/micropipenv.py | /usr/bin/python3 - install -- && \
+    curl https://raw.githubusercontent.com/thoth-station/micropipenv/master/micropipenv.py | MICROPIPENV_NO_LOCKFILE_WRITE=1 MICROPIPENV_PIP_BIN=/usr/bin/pip3 /usr/bin/python3 - install -- && \
     curl "https://raw.githubusercontent.com/thoth-station/s2i-thoth/master/assemble" -o "${TMPFILE_ASSEMBLE}" && \
     cp "${STI_SCRIPTS_PATH}/assemble" "${TMPFILE}" && \
     head -n1 "${TMPFILE}" >"${STI_SCRIPTS_PATH}/assemble" && \


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/s2i-thoth/issues/201

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Move env variables after pipe to be correctly used by the scirpt and not by the curl command. (check https://github.com/sclorg/s2i-python-container/issues/466 for more details)
