### PR TITLE
Docker build optimization

### DIFF
--- a/ubi8-py36/Dockerfile
+++ b/ubi8-py36/Dockerfile
@@ -44,6 +44,6 @@ RUN TMPFILE=$(mktemp) && \
     fix-permissions ${APP_ROOT} -P && \
     yum update --assumeyes --setopt=tsflags=nodocs && \
     yum --assumeyes clean all && \
-    rm -rf /var/cache/yum
+    rm -rf /var/cache/dnf
 
 USER 1001

--- a/ubi8-py36/Dockerfile
+++ b/ubi8-py36/Dockerfile
@@ -42,6 +42,8 @@ RUN TMPFILE=$(mktemp) && \
     sed -i '/  echo "---> Running application from .*/d' "${STI_SCRIPTS_PATH}/run" && \
     chown -R 1001:0 ${APP_ROOT} && \
     fix-permissions ${APP_ROOT} -P && \
-    yum update --assumeyes --setopt=tsflags=nodocs
+    yum update --assumeyes --setopt=tsflags=nodocs && \
+    yum --assumeyes clean all && \
+    rm -rf /var/cache/yum
 
 USER 1001

--- a/ubi8-py38/Dockerfile
+++ b/ubi8-py38/Dockerfile
@@ -44,6 +44,6 @@ RUN TMPFILE=$(mktemp) && \
     fix-permissions ${APP_ROOT} -P && \
     yum update --assumeyes --nobest --setopt=tsflags=nodocs && \
     yum --assumeyes clean all && \
-    rm -rf /var/cache/yum
+    rm -rf /var/cache/dnf
 
 USER 1001

--- a/ubi8-py38/Dockerfile
+++ b/ubi8-py38/Dockerfile
@@ -42,6 +42,8 @@ RUN TMPFILE=$(mktemp) && \
     sed -i '/  echo "---> Running application from .*/d' "${STI_SCRIPTS_PATH}/run" && \
     chown -R 1001:0 ${APP_ROOT} && \
     fix-permissions ${APP_ROOT} -P && \
-    yum update --assumeyes --nobest --setopt=tsflags=nodocs
+    yum update --assumeyes --nobest --setopt=tsflags=nodocs && \
+    yum --assumeyes clean all && \
+    rm -rf /var/cache/yum
 
 USER 1001

--- a/ubi8-py39/Dockerfile
+++ b/ubi8-py39/Dockerfile
@@ -44,6 +44,6 @@ RUN TMPFILE=$(mktemp) && \
     fix-permissions ${APP_ROOT} -P && \
     yum update --assumeyes --nobest --setopt=tsflags=nodocs && \
     yum --assumeyes clean all && \
-    rm -rf /var/cache/yum
+    rm -rf /var/cache/dnf
 
 USER 1001

--- a/ubi8-py39/Dockerfile
+++ b/ubi8-py39/Dockerfile
@@ -42,6 +42,8 @@ RUN TMPFILE=$(mktemp) && \
     sed -i '/  echo "---> Running application from .*/d' "${STI_SCRIPTS_PATH}/run" && \
     chown -R 1001:0 ${APP_ROOT} && \
     fix-permissions ${APP_ROOT} -P && \
-    yum update --assumeyes --nobest --setopt=tsflags=nodocs
+    yum update --assumeyes --nobest --setopt=tsflags=nodocs && \
+    yum --assumeyes clean all && \
+    rm -rf /var/cache/yum
 
 USER 1001


### PR DESCRIPTION
## This introduces a breaking change

- [ ] Yes
- [X ] No

## This Pull Request implements

Add cleaning instructions after yum update in the Dockerfile(s) to gain size on images.
Gain is not that important, image size for ubi8-py38 is 1.1GB vs 1.11GB without it, but it's best practice in general.

## Description

Simply added instructions after the yum update.
yum --assumeyes clean all && \
rm -rf /var/cache/yum
