### PR TITLE
Pip no cache dir

### DIFF
--- a/f34-py39/Dockerfile
+++ b/f34-py39/Dockerfile
@@ -1,5 +1,5 @@
 # Thoth's extension to OpenShift's S2I build
-FROM registry.fedoraproject.org/f34/python3:latest
+FROM registry.fedoraproject.org/f34/python3:0-31.container
 
 ENV SUMMARY="Thoth's Source-to-Image for Python ${PYTHON_VERSION} applications" \
     DESCRIPTION="Thoth's Source-to-Image for Python ${PYTHON_VERSION} applications. This toolchain is based on Fedora 34. It includes Pipenv." \
@@ -30,8 +30,8 @@ COPY ./requirements.txt $HOME/requirements.txt
 RUN TMPFILE=$(mktemp) && \
     TMPFILE_ASSEMBLE=$(mktemp) && \
     pushd "${STI_SCRIPTS_PATH}" && patch -p 1 </tmp/s2i_assemble.patch && popd && \
-    pip3 install -U "pip==20.3.3" && \
-    /usr/bin/pip3 install -U "pip==20.3.3" && \
+    pip3 --no-cache-dir install -U "pip==20.3.3" && \
+    /usr/bin/pip3 --no-cache-dir install -U "pip==20.3.3" && \
     curl https://raw.githubusercontent.com/thoth-station/micropipenv/master/micropipenv.py | MICROPIPENV_NO_LOCKFILE_WRITE=1 MICROPIPENV_PIP_BIN=/usr/bin/pip3 /usr/bin/python3 - install -- && \
     curl "https://raw.githubusercontent.com/thoth-station/s2i-thoth/master/assemble" -o "${TMPFILE_ASSEMBLE}" && \
     cp "${STI_SCRIPTS_PATH}/assemble" "${TMPFILE}" && \

--- a/f34-py39/s2i_assemble.patch
+++ b/f34-py39/s2i_assemble.patch
@@ -1,9 +1,9 @@
---- a/assemble    2020-10-31 11:55:38.000000000 +0100
-+++ b/assemble    2020-11-25 22:32:16.739312082 +0100
-@@ -18,38 +18,8 @@
-   fi
+--- a/assemble	2021-09-12 14:46:51.130401513 -0400
++++ b/assemble	2021-09-12 14:49:27.881361622 -0400
+@@ -14,38 +14,8 @@
+     python3.9 -m venv $1
  }
-
+ 
 -# Install pipenv or micropipenv to the separate virtualenv to isolate it
 -# from system Python packages and packages in the main
 -# virtualenv. Executable is simlinked into ~/.local/bin
@@ -27,7 +27,7 @@
 -}
 -
  set -e
-
+ 
 -# First of all, check that we don't have disallowed combination of ENVs
 -if [[ ! -z "$ENABLE_PIPENV" && ! -z "$ENABLE_MICROPIPENV" ]]; then
 -  echo "ERROR: Pipenv and micropipenv cannot be enabled at the same time!"
@@ -39,10 +39,10 @@
  shopt -s dotglob
  echo "---> Installing application source ..."
  mv /tmp/src/* "$HOME"
-@@ -57,16 +27,6 @@
+@@ -53,50 +23,19 @@
  # set permissions for any installed artifacts
  fix-permissions /opt/app-root -P
-
+ 
 -# We have to first upgrade pip to at least 19.3 because:
 -# * pip < 9 does not support different packages' versions for Python 2/3
 -# * pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 wheels
@@ -55,11 +55,14 @@
 -
  if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
    echo "---> Upgrading pip to latest version ..."
-   if ! pip install -U pip setuptools wheel; then
-@@ -75,28 +35,7 @@
+-  if ! pip install -U pip setuptools wheel; then
++  if ! pip install --no-cache-dir -U pip setuptools wheel; then
+     echo "WARNING: Installation of the latest pip,setuptools and wheel failed, trying again from official PyPI with pip --isolated install"
+-    pip install --isolated -U pip setuptools wheel
++    pip install --no-cache-dir --isolated -U pip setuptools wheel
    fi
  fi
-
+ 
 -if [[ ! -z "$ENABLE_PIPENV" ]]; then
 -  if [[ ! -z "$PIN_PIPENV_VERSION" ]]; then
 -    # Add == as a prefix to pipenv version, if defined
@@ -83,6 +86,11 @@
 -  pip install -r requirements.txt
 -fi
 +thamos install
-
+ 
  if [[ -f setup.py && -z "$DISABLE_SETUP_PY_PROCESSING" ]]; then
    echo "---> Installing application ..."
+-  pip install .
++  pip install --no-cache-dir .
+ fi
+ 
+ if should_collectstatic; then


### PR DESCRIPTION
## This introduces a breaking change

- [ ] Yes
- [X ] No

## This Pull Request implements

- Fix the version of the base image `registry.fedoraproject.org/f34/python3`. With `latest` the assemble patch was not valid anymore. Other solution would be to constantly maintain the assemble patch to reflect changes in base image.
- Added the `no-cache-dir` option to the all the pip install to minimize the image size.
