### PR TITLE
update all the Python UBI8 base images

### DIFF
--- a/ubi8-py36/Dockerfile
+++ b/ubi8-py36/Dockerfile
@@ -1,10 +1,10 @@
 # Thoth's extension to OpenShift's S2I build
-FROM registry.access.redhat.com/ubi8/python-36:1-148
+FROM registry.access.redhat.com/ubi8/python-36:1-155
 
 ENV SUMMARY="Thoth's Source-to-Image for Python ${PYTHON_VERSION} applications" \
     DESCRIPTION="Thoth's Source-to-Image for Python ${PYTHON_VERSION} applications. This toolchain is based on Red Hat UBI8. It includes pipenv." \
     THOTH_S2I_NAME=quay.io/thoth-station/s2i-thoth-ubi8-py36 \
-    THOTH_S2I_VERSION=0.31.1 \
+    THOTH_S2I_VERSION=0.32.0 \
     THAMOS_NO_PROGRESSBAR=1 \
     THAMOS_NO_EMOJI=1 \
     MICROPIPENV_NO_LOCKFILE_PRINT=0 \

--- a/ubi8-py38/Dockerfile
+++ b/ubi8-py38/Dockerfile
@@ -1,10 +1,10 @@
 # Thoth's extension to OpenShift's S2I build
-FROM registry.access.redhat.com/ubi8/python-38:1-60
+FROM registry.access.redhat.com/ubi8/python-38:1-71
 
 ENV SUMMARY="Thoth's Source-to-Image for Python ${PYTHON_VERSION} applications" \
     DESCRIPTION="Thoth's Source-to-Image for Python ${PYTHON_VERSION} applications. This toolchain is based on Red Hat UBI8. It includes pipenv." \
     THOTH_S2I_NAME=quay.io/thoth-station/s2i-thoth-ubi8-py38 \
-    THOTH_S2I_VERSION=0.31.1 \
+    THOTH_S2I_VERSION=0.32.0 \
     THAMOS_NO_PROGRESSBAR=1 \
     THAMOS_NO_EMOJI=1 \
     MICROPIPENV_NO_LOCKFILE_PRINT=0 \

--- a/ubi8-py39/Dockerfile
+++ b/ubi8-py39/Dockerfile
@@ -1,10 +1,10 @@
 # Thoth's extension to OpenShift's S2I build
-FROM registry.access.redhat.com/ubi8/python-39:1-10
+FROM registry.access.redhat.com/ubi8/python-39:1-18
 
 ENV SUMMARY="Thoth's Source-to-Image for Python ${PYTHON_VERSION} applications" \
     DESCRIPTION="Thoth's Source-to-Image for Python ${PYTHON_VERSION} applications. This toolchain is based on Red Hat UBI8. It includes pipenv." \
     THOTH_S2I_NAME=quay.io/thoth-station/s2i-thoth-ubi8-py39 \
-    THOTH_S2I_VERSION=0.31.1 \
+    THOTH_S2I_VERSION=0.32.0 \
     THAMOS_NO_PROGRESSBAR=1 \
     THAMOS_NO_EMOJI=1 \
     MICROPIPENV_NO_LOCKFILE_PRINT=0 \


### PR DESCRIPTION
updates all the base image to their latest tags, proposing this as `v0.32.0`

Signed-off-by: Christoph Görn <goern@redhat.com>
