### PR TITLE
installing python3.8 and bumping version of thamos to latest

### DIFF
--- a/f34-py39/Dockerfile
+++ b/f34-py39/Dockerfile
@@ -25,6 +25,7 @@ LABEL summary="$SUMMARY" \
     maintainer="Thoth Station <aicoe-thoth@redhat.com>"
 
 USER 0
+RUN sudo dnf install python3.8 -y
 COPY ./s2i_assemble.patch /tmp/s2i_assemble.patch
 COPY ./requirements.txt $HOME/requirements.txt
 RUN TMPFILE=$(mktemp) && \

--- a/f34-py39/requirements.txt
+++ b/f34-py39/requirements.txt
@@ -574,6 +574,9 @@ rfc5424-logging-handler==1.4.3 \
 rich==10.15.2; python_full_version >= '3.6.2' and python_full_version < '4.0.0' \
     --hash=sha256:1dded089b79dd042b3ab5cd63439a338e16652001f0c16e73acdcf4997ad772d \
     --hash=sha256:43b2c6ad51f46f6c94992aee546f1c177719f4e05aff8f5ea4d2efae3ebdac89
+rich-click==1.2.1; python_version >= '3.8' \
+    --hash=sha256:43edaf6f89d9597e992040a56ac7f9236952d3e8c2df47db88115bc304005dff \
+    --hash=sha256:bd93b1d418241b71272dac70c45bc1ddf7a3d12c550d918407e1ba3f8906f123
 rsa==4.8; python_version >= '3.6' \
     --hash=sha256:5c6bd9dc7a543b7fe4304a631f8a8a3b674e2bbfc49c2ae96200cdbe55df6b17 \
     --hash=sha256:95c5d300c4e879ee69708c428ba566c59478fd653cc3a22243eeb8ed846950bb
@@ -613,9 +616,9 @@ six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2' \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
 termcolor==1.1.0 \
     --hash=sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b
-thamos==1.21.1 \
-    --hash=sha256:38909ebb6345d98883fe03fd66e5204c014fafedff177662b6744b0c971467c9 \
-    --hash=sha256:b14907c7ead2a9bbeca0e80dc9a40d3c2152d7886ec5bbe9d605535cbdbf474a
+thamos==1.27.4 \
+    --hash=sha256:d5d69c900b8ca90ff2feb9b89d358abddfbfb2c580359966206b93253a3019a2 \
+    --hash=sha256:8def2131b43f0a6fb157f80dfb277ebfce387155ffb7e3da86b12ba5eef2be44
 thoth-analyzer==0.1.8 \
     --hash=sha256:3f830334a3ba725cacf64ccc756e42f0c7946fd8038da6565cb2de569ea5c9c1 \
     --hash=sha256:8a29ce615e5feddd301a8c6656132268bede23d4187a5cfb60f790f80cd04dc1


### PR DESCRIPTION
## Related Issues and Dependencies

Addresses: https://github.com/thoth-station/support/issues/204

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Bumping version of thamos, installing python3.8 so thamos install does not fail, adding other transative dependency of rich_click
